### PR TITLE
Modified behavior to fix strict warnings

### DIFF
--- a/Model/Behavior/AuditableBehavior.php
+++ b/Model/Behavior/AuditableBehavior.php
@@ -62,7 +62,7 @@ class AuditableBehavior extends ModelBehavior {
    *
    * @return  boolean
    */
-  public function beforeSave( Model $Model ) {
+  public function beforeSave( Model $Model, $options = array() ) {
     # If we're editing an existing object, save off a copy of
     # the object as it exists before any changes.
     if( !empty( $Model->id ) ) {
@@ -99,7 +99,7 @@ class AuditableBehavior extends ModelBehavior {
    *                    insertion. False otherwise.
    * @return  void
    */
-  public function afterSave( Model $Model, $created ) {
+  public function afterSave( Model $Model, $created, $options = array() ) {
     $audit = array( $Model->alias => $this->_getModelData( $Model ) );
     $audit[$Model->alias][$Model->primaryKey] = $Model->id;
 


### PR DESCRIPTION
When loading the plugin on PHP: PHP 5.4.4-14+deb7u4 (cli) (built: Aug 23 2013 14:37:41) following errors show up:

Strict (2048): Declaration of AuditableBehavior::beforeSave() should be compatible with ModelBehavior::beforeSave(Model $model, $options = Array) [ROOT/**/AuditLog/Model/Behavior/AuditableBehavior.php, line 312]
Strict (2048): Declaration of AuditableBehavior::afterSave() should be compatible with ModelBehavior::afterSave(Model $model, $created, $options = Array) [ROOT/**/AuditLog/Model/Behavior/AuditableBehavior.php, line 312]

Fixed by adding the 2 parameters which are un-used off-course.
