### PR TITLE
Add support for a request_id field that gets generated once per request (to group multiple changes by request)

### DIFF
--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -59,6 +59,7 @@ class AuditLogSchema extends CakeSchema {
         'event' => array('type' => 'string', 'null' => false, 'default' => NULL, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
         'model' => array('type' => 'string', 'null' => false, 'default' => NULL, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
         'entity_id' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 36, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
+        'request_id' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 36, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
         'json_object' => array('type' => 'text', 'null' => false, 'default' => NULL, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
         'description' => array('type' => 'text', 'null' => true, 'default' => NULL, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),
         'source_id' => array('type' => 'string', 'null' => true, 'default' => NULL, 'collate' => 'utf8_general_ci', 'comment' => '', 'charset' => 'utf8'),

--- a/Config/Schema/schema.sql
+++ b/Config/Schema/schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS `audits` (
   `event` varchar(255) NOT NULL,
   `model` varchar(255) NOT NULL,
   `entity_id` varchar(36) NOT NULL,
+  `request_id` varchar(36) NOT NULL,
   `json_object` text NOT NULL,
   `description` text,
   `source_id` varchar(255) DEFAULT NULL,

--- a/Model/Behavior/AuditableBehavior.php
+++ b/Model/Behavior/AuditableBehavior.php
@@ -13,6 +13,18 @@ class AuditableBehavior extends ModelBehavior {
   private $_original = array();
 
   /**
+  * The request_id, a unique ID generated once per request to allow multiple record changes to be grouped by request
+  */
+  private static $_request_id = null;
+  private function request_id() {
+    if (empty(self::$_request_id)) {
+      self::$_request_id = String::uuid();
+    }
+
+    return self::$_request_id;
+  }
+
+  /**
    * Initiate behavior for the model using specified settings.
    *
    * Available settings:
@@ -131,6 +143,7 @@ class AuditableBehavior extends ModelBehavior {
         'event'     => $created ? 'CREATE' : 'EDIT',
         'model'     => $Model->alias,
         'entity_id' => $Model->id,
+		'request_id' => self::request_id(),
         'json_object' => json_encode( $audit ),
         'source_id' => isset( $source['id'] ) ? $source['id'] : null,
         'description' => isset( $source['description'] ) ? $source['description'] : null,
@@ -250,6 +263,7 @@ class AuditableBehavior extends ModelBehavior {
         'event'       => 'DELETE',
         'model'       => $Model->alias,
         'entity_id'   => $Model->id,
+		'request_id' => self::request_id(),
         'json_object' => json_encode( $audit ),
         'source_id'   => isset( $source['id'] ) ? $source['id'] : null,
         'description' => isset( $source['description'] ) ? $source['description'] : null,


### PR DESCRIPTION
This seems like an obvious one for me, create a static request_id field that gets generated once per request, and set that field for each audit record. So if my user clicks "publish website" and that action generates a dozen queries, they all get grouped together. Presumably then you can use the "created date" for one of the audit records to determine the "request date".