### PR TITLE
Skip, if no ID was given on delete

### DIFF
--- a/Model/Behavior/AuditableBehavior.php
+++ b/Model/Behavior/AuditableBehavior.php
@@ -106,6 +106,11 @@ class AuditableBehavior extends \ModelBehavior {
 			return true;
 		}
 
+		// Skip, if no ID to delete was given.
+		if ($Model->id === false) {
+			return true;
+		}
+
 		$original = $Model->find(
 			'first',
 			array(


### PR DESCRIPTION
Without this, it would emit a notice about the model name was not found as array key in the result set in ``beforeDelete()``