### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ class AnotherModel extends AppModel {
 
 	// More model code here.
 }
-````
+`````
 
 ### Callbacks
 


### PR DESCRIPTION
Missing ` on line 155 caused code block to stay open through rest of file.