### PR TITLE
Added plugin syntax for model names.

### DIFF
--- a/Model/Behavior/AuditableBehavior.php
+++ b/Model/Behavior/AuditableBehavior.php
@@ -186,7 +186,7 @@ class AuditableBehavior extends \ModelBehavior {
 		$data = array(
 			'Audit' => array(
 				'event' => $created ? 'CREATE' : 'EDIT',
-				'model' => $Model->alias,
+				'model' => $Model->plugin ? $Model->plugin . '.' . $Model->alias : $Model->alias,
 				'entity_id' => $Model->id,
 				'request_id' => self::_requestId(),
 				'json_object' => json_encode($audit),
@@ -308,7 +308,7 @@ class AuditableBehavior extends \ModelBehavior {
 		$data = array(
 			'Audit' => array(
 				'event' => 'DELETE',
-				'model' => $Model->alias,
+				'model' => $Model->plugin ? $Model->plugin . '.' . $Model->alias : $Model->alias,
 				'entity_id' => $Model->id,
 				'request_id' => self::_requestId(),
 				'json_object' => json_encode($audit),


### PR DESCRIPTION
This will resolve issue #79 . Model names will be stored in the audits table as Plugin.Model (e.g. Contacts.Client), where applicable. For root app models, they'll be stored as just Model (e.g. User).