### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/Model/Behavior/AuditableBehavior.php
+++ b/Model/Behavior/AuditableBehavior.php
@@ -219,7 +219,7 @@ class AuditableBehavior extends \ModelBehavior {
 			} else {
 				if ((Hash::check($this->_getOriginalDataForModel($Model), $property)
 					&& Hash::get($this->_getOriginalDataForModel($Model), $property) != $value
-				) || (Hash::get($this->_getOriginalDataForModel($Model), $property) == NULl &&  $value != NULL and $value!="")) {
+				) || (Hash::get($this->_getOriginalDataForModel($Model), $property) == null &&  $value != null and $value!="")) {
 					// If the property exists in the original _and_ the
 					// value is different, store it.
 					$delta = array(


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!